### PR TITLE
refac(initializer): mv from main to module

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -1,4 +1,5 @@
 program tcell
+  use tcelsim, only : initialize_positions
   implicit none
 
   integer ncells, npositions, nintervals
@@ -66,30 +67,6 @@ contains
     end do
 
   end subroutine move_tcells
-
-  subroutine initialize_positions(x,y,z,ncells,npositions)
-        
-    implicit none
-    integer ncells,npositions
-    double precision x(ncells,npositions)
-    double precision y(ncells,npositions)
-    double precision z(ncells,npositions)
-
-    !     Local variables
-    integer i
-    double precision rr1,rr2,rr3
-        
-    !     Assign initial positions to T cells randomly in a [100x100x100] grid
-    do i = 1,ncells
-       call random_number(rr1)
-       call random_number(rr2)
-       call random_number(rr3)
-       x(i,1) = rr1*100.d0
-       y(i,1) = rr2*100.d0
-       z(i,1) = rr3*100.d0
-    end do
-
-  end subroutine initialize_positions
 
   subroutine create_distribution(vel,cumulative_distribution,nintervals)
     implicit none

--- a/src/tcelsim.f90
+++ b/src/tcelsim.f90
@@ -1,10 +1,4 @@
 module tcelsim
+  use t_cell_m, only : initialize_positions
   implicit none
-  private
-
-  public :: say_hello
-contains
-  subroutine say_hello
-    print *, "Hello, tcelsim!"
-  end subroutine say_hello
-end module tcelsim
+end module

--- a/src/tcelsim/t_cell.f90
+++ b/src/tcelsim/t_cell.f90
@@ -1,0 +1,30 @@
+module t_cell_m
+  implicit none
+
+contains
+  
+  subroutine initialize_positions(x,y,z,ncells,npositions)
+        
+    implicit none
+    integer ncells,npositions
+    double precision x(ncells,npositions)
+    double precision y(ncells,npositions)
+    double precision z(ncells,npositions)
+
+    !     Local variables
+    integer i
+    double precision rr1,rr2,rr3
+        
+    !     Assign initial positions to T cells randomly in a [100x100x100] grid
+    do i = 1,ncells
+       call random_number(rr1)
+       call random_number(rr2)
+       call random_number(rr3)
+       x(i,1) = rr1*100.d0
+       y(i,1) = rr2*100.d0
+       z(i,1) = rr3*100.d0
+    end do
+
+  end subroutine initialize_positions
+
+end module t_cell_m


### PR DESCRIPTION
This commit moves the initialize_positions subroutien to a module
in src/tcelsim and adds a new global module inside
src/tcelsim/tcelsim.f90. The new global module will contain a use
for each new module defined in the project.