### PR TITLE
Refactor the new distribution test

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -1,6 +1,6 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
-program matcha_app
+program main
   !! Matcha: Motility Analysis of T-Cell Histories in Activation
   use matcha_m, only : matcha, input_t, output_t
   implicit none

--- a/app/matcha.f90
+++ b/app/matcha.f90
@@ -2,10 +2,12 @@
 ! Terms of use are as specified in LICENSE.txt
 program matcha_app
   !! Matcha: Motility Analysis of T-Cell Histories in Activation
-  use matcha_m, only : matcha, input_t
+  use matcha_m, only : matcha, input_t, output_t
   implicit none
+  type(output_t) output
 
-  associate(history => matcha(input_t()))
+  associate(input => input_t())
+    output = output_t(input, matcha(input))
   end associate
 
   print *

--- a/src/matcha/distribution_m.f90
+++ b/src/matcha/distribution_m.f90
@@ -1,5 +1,3 @@
-! Copyright (c), The Regents of the University of California
-! Terms of use are as specified in LICENSE.txt
 module distribution_m
   implicit none
   
@@ -12,13 +10,14 @@ module distribution_m
   contains
     procedure :: cumulative_distribution
     procedure :: velocities
+    procedure :: build_distribution
   end type  
 
   interface distribution_t
   
    pure module function construct(sample_distribution) result(distribution)
       implicit none
-      double precision, intent(in) :: sample_distribution(:)
+      double precision, intent(in) :: sample_distribution(:,:)
       type(distribution_t) distribution
     end function
     
@@ -38,6 +37,13 @@ module distribution_m
       class(distribution_t), intent(in) :: self
       double precision, intent(in) :: speeds(:,:), directions(:,:,:)
       double precision, allocatable :: my_velocities(:,:,:)
+    end function velocities
+
+    pure module function build_distribution(self, emp_distribution, speeds) result(sim_distribution)
+      implicit none
+      class(distribution_t), intent(in) :: self
+      double precision, intent(in) :: speeds(:),emp_distribution(:,:)
+      double precision, allocatable :: sim_distribution(:,:)
     end function
     
   end interface

--- a/src/matcha/distribution_m.f90
+++ b/src/matcha/distribution_m.f90
@@ -10,7 +10,7 @@ module distribution_m
   contains
     procedure :: cumulative_distribution
     procedure :: velocities
-    procedure :: build_distribution
+    procedure, nopass :: build_distribution
   end type  
 
   interface distribution_t
@@ -39,9 +39,8 @@ module distribution_m
       double precision, allocatable :: my_velocities(:,:,:)
     end function velocities
 
-    pure module function build_distribution(self, emp_distribution, speeds) result(sim_distribution)
+    pure module function build_distribution(emp_distribution, speeds) result(sim_distribution)
       implicit none
-      class(distribution_t), intent(in) :: self
       double precision, intent(in) :: speeds(:),emp_distribution(:,:)
       double precision, allocatable :: sim_distribution(:,:)
     end function

--- a/src/matcha/distribution_m.f90
+++ b/src/matcha/distribution_m.f90
@@ -10,7 +10,6 @@ module distribution_m
   contains
     procedure :: cumulative_distribution
     procedure :: velocities
-    procedure, nopass :: build_distribution
   end type  
 
   interface distribution_t
@@ -39,12 +38,6 @@ module distribution_m
       double precision, allocatable :: my_velocities(:,:,:)
     end function velocities
 
-    pure module function build_distribution(emp_distribution, speeds) result(sim_distribution)
-      implicit none
-      double precision, intent(in) :: speeds(:),emp_distribution(:,:)
-      double precision, allocatable :: sim_distribution(:,:)
-    end function
-    
   end interface
-  
+
 end module distribution_m

--- a/src/matcha/distribution_m.f90
+++ b/src/matcha/distribution_m.f90
@@ -1,3 +1,5 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
 module distribution_m
   implicit none
   

--- a/src/matcha/distribution_s.f90
+++ b/src/matcha/distribution_s.f90
@@ -78,28 +78,28 @@ contains
   end procedure
 
   module procedure build_distribution
-  integer i
-  integer, allocatable :: k(:)
-  double precision, allocatable :: vel(:)
-  
-  associate(nintervals => size(emp_distribution(:,1)))
-    allocate(sim_distribution(nintervals,2))
-    sim_distribution(:,2) = 0.d0
-    sim_distribution(:,1) = emp_distribution(:,1)
-    associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
-      vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
-      associate(nspeeds => size(speeds))
-        allocate(k(nspeeds))
-        do concurrent(i = 1:nspeeds)
-          k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
+    integer i
+    integer, allocatable :: k(:)
+    double precision, allocatable :: vel(:)
+    
+    associate(nintervals => size(emp_distribution(:,1)))
+      allocate(sim_distribution(nintervals,2))
+      sim_distribution(:,2) = 0.d0
+      sim_distribution(:,1) = emp_distribution(:,1)
+      associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
+        vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
+        associate(nspeeds => size(speeds))
+          allocate(k(nspeeds))
+          do concurrent(i = 1:nspeeds)
+            k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
+          end do
+        end associate
+        do concurrent(i = 1:size(sim_distribution,1))
+          sim_distribution(i,2) = count(k==i)
         end do
+        sim_distribution(:,2) = sim_distribution(:,2)/sum(sim_distribution(:,2))
       end associate
-      do concurrent(i = 1:size(sim_distribution,1))
-        sim_distribution(i,2) = count(k==i)
-      end do
-      sim_distribution(:,2) = sim_distribution(:,2)/sum(sim_distribution(:,2))
     end associate
-  end associate
-  
   end procedure
+
 end submodule distribution_s

--- a/src/matcha/distribution_s.f90
+++ b/src/matcha/distribution_s.f90
@@ -93,6 +93,10 @@ contains
          vel(i+1) = emp_distribution(i,1) + dvel_half
       end do
       associate(nspeeds => size(speeds))
+        !do concurrent(i=1:nspeed)
+        !  sim_distribution(:,2) = count(speeds >= vel(1:nspeeds-1) .and. speeds < vel(2:nspeeds))
+        !end do
+
         do i = 1,nspeeds
            k = findloc(speeds(i) >= vel, value=.false., dim=1)-1
            sim_distribution(k,2) = sim_distribution(k,2) + 1.d0

--- a/src/matcha/distribution_s.f90
+++ b/src/matcha/distribution_s.f90
@@ -78,7 +78,8 @@ contains
   end procedure
 
   module procedure build_distribution
-  integer i,k
+  integer i, j
+  integer, allocatable :: k(:)
   double precision, allocatable :: vel(:)
   
   associate(nintervals => size(emp_distribution(:,1)))
@@ -93,13 +94,12 @@ contains
          vel(i+1) = emp_distribution(i,1) + dvel_half
       end do
       associate(nspeeds => size(speeds))
-        !do concurrent(i=1:nspeed)
-        !  sim_distribution(:,2) = count(speeds >= vel(1:nspeeds-1) .and. speeds < vel(2:nspeeds))
-        !end do
-
+        allocate(k(nspeeds))
         do i = 1,nspeeds
-           k = findloc(speeds(i) >= vel, value=.false., dim=1)-1
-           sim_distribution(k,2) = sim_distribution(k,2) + 1.d0
+          k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
+        end do
+        do j = 1,size(sim_distribution,1)
+          sim_distribution(j,2) = count(k==j)
         end do
         sim_distribution(:,2) = sim_distribution(:,2)/sum(sim_distribution(1:nintervals,2))
       end associate

--- a/src/matcha/distribution_s.f90
+++ b/src/matcha/distribution_s.f90
@@ -77,29 +77,4 @@ contains
 
   end procedure
 
-  module procedure build_distribution
-    integer i
-    integer, allocatable :: k(:)
-    double precision, allocatable :: vel(:)
-    
-    associate(nintervals => size(emp_distribution(:,1)))
-      allocate(sim_distribution(nintervals,2))
-      sim_distribution(:,2) = 0.d0
-      sim_distribution(:,1) = emp_distribution(:,1)
-      associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
-        vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
-        associate(nspeeds => size(speeds))
-          allocate(k(nspeeds))
-          do concurrent(i = 1:nspeeds)
-            k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
-          end do
-        end associate
-        do concurrent(i = 1:size(sim_distribution,1))
-          sim_distribution(i,2) = count(k==i)
-        end do
-        sim_distribution(:,2) = sim_distribution(:,2)/sum(sim_distribution(:,2))
-      end associate
-    end associate
-  end procedure
-
 end submodule distribution_s

--- a/src/matcha/input_m.f90
+++ b/src/matcha/input_m.f90
@@ -8,14 +8,17 @@ module input_m
   
   type input_t
     private
-    integer :: num_cells_ = 100, num_positions_ = 25, num_dimensions_ = 3, num_intervals_ = 10
+    integer :: num_cells_ = 1000, num_positions_ = 1000, num_dimensions_ = 3, num_intervals_ = 4
     double precision :: time_step_ = 0.1D0
+    !double precision, allocatable :: sample_distribution_(:,:)
+    !allocate(sample_distribution_(num_intervals_,2))
   contains
     procedure :: num_cells
     procedure :: num_positions
     procedure :: num_dimensions
     procedure :: num_intervals
     procedure :: time_step
+    procedure :: sample_distribution
   end type
   
   interface
@@ -48,7 +51,13 @@ module input_m
       implicit none
       class(input_t), intent(in) :: self
       double precision dt
-    end function
+    end function time_step
+    
+    pure module function sample_distribution(self) result(empirical_distribution)
+      implicit none
+      class(input_t), intent(in) :: self
+      double precision, allocatable :: empirical_distribution(:,:)
+    end function sample_distribution    
     
   end interface
   

--- a/src/matcha/input_s.f90
+++ b/src/matcha/input_s.f90
@@ -5,24 +5,64 @@ submodule(input_m) input_s
 
 contains
       
-   module procedure num_cells
-       n = self%num_cells_
-   end procedure
+  module procedure num_cells
+      n = self%num_cells_
+  end procedure
    
   module procedure num_positions
       n = self%num_positions_
   end procedure
   
- module procedure num_dimensions
-     n = self%num_dimensions_
- end procedure
+  module procedure num_dimensions
+      n = self%num_dimensions_
+  end procedure
 
- module procedure num_intervals
-   n = self%num_intervals_
- end procedure
+  module procedure num_intervals
+      n = self%num_intervals_
+  end procedure
 
- module procedure time_step
-   dt = self%time_step_
- end procedure
+  module procedure time_step
+      dt = self%time_step_
+  end procedure
+
+  module procedure sample_distribution
+     integer i,nintervals
+     double precision speed_lower,speed_upper
+     double precision range,pi,dspeed,sumy
+     double precision speed_lower_bin
+     double precision speed_upper_bin
+     double precision speed_middle_bin
+     double precision, allocatable :: speeds(:),probability(:)
+     nintervals = self%num_intervals_
+
+     speed_lower = 0.d0
+     speed_upper = 6.d0
+     range = speed_upper - speed_lower
+     pi = acos(-1.d0)
+     dspeed = range/dble(nintervals)
+     allocate(speeds(nintervals),probability(nintervals))
+!    Create normal distribution     
+     sumy = 0.d0
+     do i = 1,nintervals
+        speed_lower_bin = speed_lower + dble(i-1)*dspeed
+        speed_upper_bin = speed_lower + dble(i)*dspeed
+        speed_middle_bin = 0.5d0*(speed_lower_bin + speed_upper_bin)
+        speeds(i) = speed_middle_bin
+        probability(i) = exp(-(speeds(i)-3.d0)**2/2.d0)/dsqrt(2.d0*pi) ! Use normal distribution
+        sumy = sumy + probability(i)
+     end do
+
+     do i = 1,nintervals
+        probability(i) = probability(i)/sumy
+     end do
+      
+     allocate(empirical_distribution(nintervals,2))
+      
+     do i = 1,nintervals
+         empirical_distribution(i,1) = speeds(i)
+         empirical_distribution(i,2) = probability(i)
+     end do
+      
+  end procedure    
  
 end submodule input_s

--- a/src/matcha/output_m.f90
+++ b/src/matcha/output_m.f90
@@ -1,6 +1,7 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 module output_m
+  !! Output data abstraction
   use input_m, only : input_t
   use t_cell_collection_m, only : t_cell_collection_t
   implicit none
@@ -9,6 +10,7 @@ module output_m
   public :: output_t
   
   type output_t
+    !! Encapsulate an input/result pair
     private
     type(input_t) input_
     type(t_cell_collection_t), allocatable :: history_(:)
@@ -19,6 +21,7 @@ module output_m
   interface output_t
 
     pure module function construct(input, history) result(output)
+      !! Construct a new output_t object
       implicit none
       type(input_t), intent(in) :: input
       type(t_cell_collection_t), intent(in) :: history(:)
@@ -30,6 +33,7 @@ module output_m
   interface
     
     pure module function simulated_distribution(self) result(output_distribution)
+      !! The result is a histogram calculated from the simulation output
       implicit none
       class(output_t), intent(in) :: self
       double precision, allocatable :: output_distribution(:,:)

--- a/src/matcha/output_m.f90
+++ b/src/matcha/output_m.f90
@@ -1,0 +1,41 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+module output_m
+  use input_m, only : input_t
+  use t_cell_collection_m, only : t_cell_collection_t
+  implicit none
+  
+  private
+  public :: output_t
+  
+  type output_t
+    private
+    type(input_t) input_
+    type(t_cell_collection_t), allocatable :: history_(:)
+  contains
+    procedure :: build_distribution
+  end type
+  
+  interface output_t
+
+    pure module function construct(input, history) result(output)
+      implicit none
+      type(input_t), intent(in) :: input
+      type(t_cell_collection_t), intent(in) :: history(:)
+      type(output_t) :: output
+    end function
+
+  end interface
+
+  interface
+    
+    pure module function build_distribution(self, speeds) result(sim_distribution)
+      implicit none
+      class(output_t), intent(in) :: self
+      double precision, intent(in) :: speeds(:)
+      double precision, allocatable :: sim_distribution(:,:)
+    end function
+    
+  end interface
+  
+end module output_m

--- a/src/matcha/output_m.f90
+++ b/src/matcha/output_m.f90
@@ -13,7 +13,7 @@ module output_m
     type(input_t) input_
     type(t_cell_collection_t), allocatable :: history_(:)
   contains
-    procedure :: build_distribution
+    procedure :: simulated_distribution
   end type
   
   interface output_t
@@ -29,11 +29,10 @@ module output_m
 
   interface
     
-    pure module function build_distribution(self, speeds) result(sim_distribution)
+    pure module function simulated_distribution(self) result(output_distribution)
       implicit none
       class(output_t), intent(in) :: self
-      double precision, intent(in) :: speeds(:)
-      double precision, allocatable :: sim_distribution(:,:)
+      double precision, allocatable :: output_distribution(:,:)
     end function
     
   end interface

--- a/src/matcha/output_s.f90
+++ b/src/matcha/output_s.f90
@@ -1,0 +1,40 @@
+! Copyright (c), The Regents of the University of California
+! Terms of use are as specified in LICENSE.txt
+submodule(output_m) output_s
+  implicit none
+  
+contains
+
+  module procedure construct
+    output%input_ = input
+    output%history_ = history
+  end procedure
+
+  module procedure build_distribution
+    integer i
+    integer, allocatable :: k(:)
+    double precision, allocatable :: vel(:)
+    
+    associate(emp_distribution => self%input_%sample_distribution())
+      associate(nintervals => size(emp_distribution(:,1)))
+        allocate(sim_distribution(nintervals,2))
+        sim_distribution(:,2) = 0.d0
+        sim_distribution(:,1) = emp_distribution(:,1)
+        associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
+          vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
+          associate(nspeeds => size(speeds))
+            allocate(k(nspeeds))
+            do concurrent(i = 1:nspeeds)
+              k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
+            end do
+          end associate
+          do concurrent(i = 1:size(sim_distribution,1))
+            sim_distribution(i,2) = count(k==i)
+          end do
+          sim_distribution(:,2) = sim_distribution(:,2)/sum(sim_distribution(:,2))
+        end associate
+      end associate
+    end associate
+  end procedure
+
+end submodule output_s

--- a/src/matcha/output_s.f90
+++ b/src/matcha/output_s.f90
@@ -10,16 +10,17 @@ contains
     output%history_ = history
   end procedure
 
-  module procedure build_distribution
+  module procedure simulated_distribution
     integer i
     integer, allocatable :: k(:)
     double precision, allocatable :: vel(:)
-    
+
+    associate(speeds => sim_speeds(self%history_))
     associate(emp_distribution => self%input_%sample_distribution())
       associate(nintervals => size(emp_distribution(:,1)))
-        allocate(sim_distribution(nintervals,2))
-        sim_distribution(:,2) = 0.d0
-        sim_distribution(:,1) = emp_distribution(:,1)
+        allocate(output_distribution(nintervals,2))
+        output_distribution(:,2) = 0.d0
+        output_distribution(:,1) = emp_distribution(:,1)
         associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
           vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
           associate(nspeeds => size(speeds))
@@ -28,13 +29,47 @@ contains
               k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
             end do
           end associate
-          do concurrent(i = 1:size(sim_distribution,1))
-            sim_distribution(i,2) = count(k==i)
+          do concurrent(i = 1:size(output_distribution,1))
+            output_distribution(i,2) = count(k==i)
           end do
-          sim_distribution(:,2) = sim_distribution(:,2)/sum(sim_distribution(:,2))
+          output_distribution(:,2) = output_distribution(:,2)/sum(output_distribution(:,2))
         end associate
       end associate
     end associate
+    end associate
+
+  contains
+
+    pure function sim_speeds(history) result(speeds)
+      type(t_cell_collection_t), intent(in) :: history(:)
+      double precision, allocatable :: speeds(:)
+
+      integer, parameter :: nspacedims=3
+      integer i, j, k
+      double precision, allocatable :: x(:,:,:)
+  
+      associate( &
+        npositions => size(history,1), &
+        ncells => size(history(1)%positions(),1) &
+      )   
+        allocate(x(npositions,ncells,nspacedims))
+        do concurrent(i=1:npositions)
+          x(i,:,:) = history(i)%positions()
+        end do
+        associate(t => history%time())
+          allocate(speeds(ncells*(npositions-1)))
+          do concurrent(i = 1:npositions-1, j = 1:ncells)
+            associate( &
+              u => (x(i+1,j,:) - x(i,j,:))/(t(i+1) - t(i)), &
+              ij => i + (j-1)*(npositions-1) &
+            )   
+              speeds(ij) = sqrt(sum([(u(k)**2, k=1,nspacedims)]))
+            end associate
+          end do
+        end associate
+      end associate
+    end function
+
   end procedure
 
 end submodule output_s

--- a/src/matcha/output_s.f90
+++ b/src/matcha/output_s.f90
@@ -16,26 +16,26 @@ contains
     double precision, allocatable :: vel(:)
 
     associate(speeds => sim_speeds(self%history_))
-    associate(emp_distribution => self%input_%sample_distribution())
-      associate(nintervals => size(emp_distribution(:,1)))
-        allocate(output_distribution(nintervals,2))
-        output_distribution(:,2) = 0.d0
-        output_distribution(:,1) = emp_distribution(:,1)
-        associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
-          vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
-          associate(nspeeds => size(speeds))
-            allocate(k(nspeeds))
-            do concurrent(i = 1:nspeeds)
-              k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
+      associate(emp_distribution => self%input_%sample_distribution())
+        associate(nintervals => size(emp_distribution(:,1)))
+          allocate(output_distribution(nintervals,2))
+          output_distribution(:,2) = 0.d0
+          output_distribution(:,1) = emp_distribution(:,1)
+          associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
+            vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
+            associate(nspeeds => size(speeds))
+              allocate(k(nspeeds))
+              do concurrent(i = 1:nspeeds)
+                k(i) = findloc(speeds(i) >= vel, value=.false., dim=1)-1
+              end do
+            end associate
+            do concurrent(i = 1:size(output_distribution,1))
+              output_distribution(i,2) = count(k==i)
             end do
+            output_distribution(:,2) = output_distribution(:,2)/sum(output_distribution(:,2))
           end associate
-          do concurrent(i = 1:size(output_distribution,1))
-            output_distribution(i,2) = count(k==i)
-          end do
-          output_distribution(:,2) = output_distribution(:,2)/sum(output_distribution(:,2))
         end associate
       end associate
-    end associate
     end associate
 
   contains

--- a/src/matcha/output_s.f90
+++ b/src/matcha/output_s.f90
@@ -14,15 +14,17 @@ contains
     integer i
     integer, allocatable :: k(:)
     double precision, allocatable :: vel(:)
+    
+    integer, parameter :: speed=1, freq=2 ! subscripts for speeds and frequencies
 
     associate(speeds => sim_speeds(self%history_))
       associate(emp_distribution => self%input_%sample_distribution())
         associate(nintervals => size(emp_distribution(:,1)))
           allocate(output_distribution(nintervals,2))
-          output_distribution(:,2) = 0.d0
-          output_distribution(:,1) = emp_distribution(:,1)
-          associate(dvel_half => (emp_distribution(2,1)-emp_distribution(1,1))/2.d0)
-            vel = [emp_distribution(1,1) - dvel_half, [(emp_distribution(i,1) + dvel_half, i=1,nintervals)]]
+          output_distribution(:,freq) = 0.d0
+          output_distribution(:,speed) = emp_distribution(:,speed)
+          associate(dvel_half => (emp_distribution(2,speed)-emp_distribution(1,speed))/2.d0)
+            vel = [emp_distribution(1,speed) - dvel_half, [(emp_distribution(i,speed) + dvel_half, i=1,nintervals)]]
             associate(nspeeds => size(speeds))
               allocate(k(nspeeds))
               do concurrent(i = 1:nspeeds)
@@ -30,9 +32,9 @@ contains
               end do
             end associate
             do concurrent(i = 1:size(output_distribution,1))
-              output_distribution(i,2) = count(k==i)
+              output_distribution(i,freq) = count(k==i)
             end do
-            output_distribution(:,2) = output_distribution(:,2)/sum(output_distribution(:,2))
+            output_distribution(:,freq) = output_distribution(:,freq)/sum(output_distribution(:,freq))
           end associate
         end associate
       end associate

--- a/src/matcha/t_cell_collection_m.f90
+++ b/src/matcha/t_cell_collection_m.f90
@@ -39,7 +39,7 @@ module t_cell_collection_m
     end function
     
     
-    pure module function time(self) result(my_time)
+    elemental module function time(self) result(my_time)
       !! Return the t_cell_collection_t object's time stamp
       implicit none
       class(t_cell_collection_t), intent(in) :: self

--- a/src/matcha_m.f90
+++ b/src/matcha_m.f90
@@ -4,6 +4,7 @@ module matcha_m
   use t_cell_collection_m, only : t_cell_collection_t
   use distribution_m, only : distribution_t
   use input_m, only : input_t
+  use output_m, only : output_t
   use data_partition_m, only : data_partition_t
   implicit none
 

--- a/src/matcha_m.f90
+++ b/src/matcha_m.f90
@@ -26,12 +26,13 @@ contains
       npositions => input%num_positions(), &
       ndim => input%num_dimensions(), &
       nintervals => input%num_intervals(), &
-      dt => input%time_step() &
+      dt => input%time_step(), &
+      empirical_distribution => input%sample_distribution() &
     )
 
       block
         double precision, parameter :: scale = 100.D0
-        double precision, allocatable :: sample_distribution(:), random_positions(:,:), random_4vectors(:,:,:)
+        double precision, allocatable :: random_positions(:,:), random_4vectors(:,:,:)
         type(distribution_t) distribution
         integer, parameter :: nveldim = 4
         integer step
@@ -46,14 +47,11 @@ contains
             
             allocate(random_positions(my_num_cells,ndim))
             call random_number(random_positions)  
-            allocate(sample_distribution(nintervals))
-            call random_number(sample_distribution)
           
             associate(nsteps => npositions -1)
               allocate(random_4vectors(my_num_cells,nsteps,nveldim))
               call random_number(random_4vectors)  
-              sample_distribution = sample_distribution/sum(sample_distribution)
-              distribution = distribution_t(sample_distribution)
+              distribution = distribution_t(empirical_distribution)
           
               associate(random_speeds => random_4vectors(:,:,1), random_directions => random_4vectors(:,:,2:4))
                 associate(v => distribution%velocities(random_speeds, random_directions))

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -31,6 +31,8 @@ contains
   function compare_distributions() result(result_)
     type(result_t) result_
     type(output_t) output
+    
+    integer, parameter :: speed=1, freq=2 ! subscripts for speeds and frequencies
 
     associate(input => input_t())
       output = output_t(input, matcha(input))
@@ -39,8 +41,8 @@ contains
         simulated_distribution => output%simulated_distribution() &
       )
         associate( &
-          diffmax_speeds=> maxval(abs(empirical_distribution(:,1)-simulated_distribution(:,1))), &
-          diffmax_freqs => maxval(abs(empirical_distribution(:,2)-simulated_distribution(:,2))) &
+          diffmax_speeds=> maxval(abs(empirical_distribution(:,speed)-simulated_distribution(:,speed))), &
+          diffmax_freqs => maxval(abs(empirical_distribution(:,freq)-simulated_distribution(:,freq))) &
         )
           result_ = &
             assert_equals_within_absolute(0.D0, diffmax_freqs, 1.D-02, "frequencies match empirical distribution") .and. &

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -6,6 +6,7 @@ module t_cell_collection_test
      result_t, test_item_t, describe, it, assert_that, assert_equals, assert_equals_within_absolute
    use t_cell_collection_m, only : t_cell_collection_t
    use input_m, only : input_t
+   use output_m, only : output_t
    use matcha_m, only : matcha
    use distribution_m, only: distribution_t
    implicit none
@@ -30,12 +31,12 @@ contains
   function compare_distributions() result(result_)
     implicit none
     type(result_t) result_
-    type(distribution_t) distribution
     type(t_cell_collection_t), allocatable :: history(:) 
+    type(output_t) output
 
     associate(input => input_t())
       associate(empirical_distribution => input%sample_distribution())
-        associate(sim_distribution => distribution%build_distribution(empirical_distribution,sim_speeds(matcha(input))))
+        associate(sim_distribution => output%build_distribution(sim_speeds(matcha(input))))
           associate( &
             diffmax_freqs => maxval(abs(empirical_distribution(:,2)-sim_distribution(:,2))), &
             diffmax_speeds=> maxval(abs(empirical_distribution(:,1)-sim_distribution(:,1))) &

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -44,9 +44,10 @@ contains
 
   contains
 
-    pure function sim_speeds(history)
+    pure function sim_speeds(history) result(speeds)
       type(t_cell_collection_t), intent(in) :: history(:)
-      double precision, allocatable :: sim_speeds(:)
+      double precision, allocatable :: speeds(:)
+
       integer, parameter :: nspacedims=3
       integer i, j, k
       double precision, allocatable :: x(:,:,:)
@@ -60,13 +61,13 @@ contains
           x(i,:,:) = history(i)%positions()
         end do
         associate(t => history%time())
-          allocate(sim_speeds(ncells*(npositions-1)))
-          do concurrent(j = 1:ncells, i = 1:npositions-1)
+          allocate(speeds(ncells*(npositions-1)))
+          do concurrent(i = 1:npositions-1, j = 1:ncells)
             associate( &
               u => (x(i+1,j,:) - x(i,j,:))/(t(i+1) - t(i)), &
               ij => i + (j-1)*(npositions-1) &
             )
-              sim_speeds(ij) = sqrt(sum([(u(k)**2, k=1,nspacedims)]))
+              speeds(ij) = sqrt(sum([(u(k)**2, k=1,nspacedims)]))
             end associate
           end do
         end associate

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -7,7 +7,8 @@ module t_cell_collection_test
    use t_cell_collection_m, only : t_cell_collection_t
    use data_partition_m, only : data_partition_t
    use input_m, only : input_t
-   use matcha_m, only : matcha
+   use matcha_m, only : matcha, input_t
+   use distribution_m, only: distribution_t
    implicit none
 
    private
@@ -21,18 +22,66 @@ contains
     tests = describe( &
      "a t_cell_collection", &
      [it( "is constructed with positions in the specified domain", check_constructed_domain), &
-      it("distributes cells across images", check_cell_distribution) &
+      it("distributes cells across images", check_cell_distribution), &
+      it("creates a simulated distribution similar to the empirical distribution",compare_distributions) &
       ] &
     )
   end function
 
+  function compare_distributions() result(result_)
+    implicit none
+    type(result_t) result_
+
+    integer i,j,k,ij,npositions,ncells
+    double precision dx,dy,dz,dt,diffmax
+    double precision, allocatable :: x(:,:,:),t(:),sim_speeds(:)
+    type(distribution_t) distribution
+  
+    associate(input => input_t())
+      associate(empirical_distribution => input%sample_distribution(),nintervals => input%num_intervals())
+        distribution = distribution_t(empirical_distribution)
+        associate(history => matcha(input_t()))
+          npositions = size(history,1)
+          ncells = size(history(1)%positions(),1)
+          allocate(x(npositions,ncells,3),t(npositions))
+          allocate(sim_speeds(ncells*(npositions-1)))
+          do i = 1,npositions
+            associate(xcell => history(i)%positions(),times => history(i)%time())
+              x(i,:,:) = xcell(:,:)
+              t(i) = times
+            end associate
+          end do
+          ij = 0
+          do j = 1,ncells
+            do i = 1,npositions-1
+               ij = ij + 1
+               dx = x(i+1,j,1) - x(i,j,1)
+               dy = x(i+1,j,2) - x(i,j,2)
+               dz = x(i+1,j,3) - x(i,j,3)
+               dt = t(i+1) - t(i)
+               sim_speeds(ij) = dsqrt((dx/dt)**2 + (dy/dt)**2 + (dz/dt)**2)
+            end do
+          end do
+        end associate
+        associate(sim_distribution => distribution%build_distribution(empirical_distribution,sim_speeds))
+          diffmax = -1.d0
+          do i = 1,nintervals
+             diffmax = max(abs(empirical_distribution(i,2)-sim_distribution(i,2)),diffmax)
+          end do
+        end associate
+      end associate
+    end associate
+!    print*,diffmax
+    result_ = assert_that(diffmax < .01, "distributions differ by more than 1 percent")
+  end function  
+  
   function check_constructed_domain() result(result_)
     type(result_t) result_
     integer, parameter :: ncells = 100, ndim = 3
     double precision random_positions(ncells,ndim)
     double precision, parameter :: scale_factor=100.D0
     type(t_cell_collection_t) t_cell_collection
-    
+
     call random_number(random_positions)    
     t_cell_collection = t_cell_collection_t(scale_factor*random_positions,time=0.D0)
     

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -31,12 +31,18 @@ contains
     implicit none
     type(result_t) result_
     type(distribution_t) distribution
+    type(t_cell_collection_t), allocatable :: history(:) 
 
     associate(input => input_t())
       associate(empirical_distribution => input%sample_distribution())
         associate(sim_distribution => distribution%build_distribution(empirical_distribution,sim_speeds(matcha(input))))
-          associate(diffmax => maxval(abs(empirical_distribution(:,2)-sim_distribution(:,2))))
-            result_ = assert_equals_within_absolute(0.D0, diffmax, 1.D-02, "distribution matches empirical distribution")
+          associate( &
+            diffmax_freqs => maxval(abs(empirical_distribution(:,2)-sim_distribution(:,2))), &
+            diffmax_speeds=> maxval(abs(empirical_distribution(:,1)-sim_distribution(:,1))) &
+          )
+            result_ = &
+              assert_equals_within_absolute(0.D0, diffmax_freqs, 1.D-02, "frequencies match empirical distribution") .and. &
+              assert_equals_within_absolute(0.D0, diffmax_speeds, 1.D-02, "speeds match empirical distribution")
           end associate
         end associate
       end associate

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -29,9 +29,7 @@ contains
   end function
 
   function compare_distributions() result(result_)
-    implicit none
     type(result_t) result_
-    type(t_cell_collection_t), allocatable :: history(:) 
     type(output_t) output
 
     associate(input => input_t())

--- a/test/t_cell_collection_test.f90
+++ b/test/t_cell_collection_test.f90
@@ -33,21 +33,21 @@ contains
     type(output_t) output
 
     associate(input => input_t())
-      associate(empirical_distribution => input%sample_distribution())
-        output = output_t(input, matcha(input))
-        associate(simulated_distribution => output%simulated_distribution())
-          associate( &
-            diffmax_freqs => maxval(abs(empirical_distribution(:,2)-simulated_distribution(:,2))), &
-            diffmax_speeds=> maxval(abs(empirical_distribution(:,1)-simulated_distribution(:,1))) &
-          )
-            result_ = &
-              assert_equals_within_absolute(0.D0, diffmax_freqs, 1.D-02, "frequencies match empirical distribution") .and. &
-              assert_equals_within_absolute(0.D0, diffmax_speeds, 1.D-02, "speeds match empirical distribution")
-          end associate
+      output = output_t(input, matcha(input))
+      associate( &
+        empirical_distribution => input%sample_distribution(), &
+        simulated_distribution => output%simulated_distribution() &
+      )
+        associate( &
+          diffmax_speeds=> maxval(abs(empirical_distribution(:,1)-simulated_distribution(:,1))), &
+          diffmax_freqs => maxval(abs(empirical_distribution(:,2)-simulated_distribution(:,2))) &
+        )
+          result_ = &
+            assert_equals_within_absolute(0.D0, diffmax_freqs, 1.D-02, "frequencies match empirical distribution") .and. &
+            assert_equals_within_absolute(0.D0, diffmax_speeds, 1.D-02, "speeds match empirical distribution")
         end associate
       end associate
     end associate
-
   end function  
   
   function check_constructed_domain() result(result_)


### PR DESCRIPTION
A candidate replacement for PR #91, this new PR
1. Defines a new `output_t` type that captures input/output pairs with the output being the history array.
2. Moves and renames `build_distribution` to `simuliated_distribution` bound to the new type.
3. Makes several `do` loops `concurrent`.
4. Collapses some loops into array statements.
5. Builds an `output_t` object in the main application.
6. Give names `speed` and `freq` to distribution array subscripts.
7. Tests both axes of the distribution.
8. Separates the `sim_speeds` calculation into a pure function.