### PR TITLE
fix: running multiple images with open-coarrays

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,6 @@ jobs:
         if [ ! -d OpenCoarrays-2.10.0 ] ; then wget -P . https://github.com/sourceryinstitute/OpenCoarrays/releases/download/2.10.0/OpenCoarrays-2.10.0.tar.gz && tar -xf OpenCoarrays-2.10.0.tar.gz && cd OpenCoarrays-2.10.0 && TERM=xterm ./install.sh -y; fi
     - name: Build, run, and test
       run: |
-        ./install.sh
+        ./setup.sh
         source OpenCoarrays-2.10.0/prerequisites/installations/opencoarrays/2.10.0/setup.sh
         ./build/run-fpm.sh test --compiler caf --runner "cafrun -n 2"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Change '2' above to the number of images that you would like to launch in parall
 ### Parallel Execution with Caffeine
 ```
 ./setup.sh
-GASNET_PSHM_NODES=2 ./build/run-fpm.sh run --flag "-DUSE_CAFFEINE"
-GASNET_PSHM_NODES=2 ./build/run-fpm.sh test --flag "-DUSE_CAFFEINE"
+GASNET_PSHM_NODES=2 ./build/run-fpm.sh run --flag "-fcoarray=single -DUSE_CAFFEINE"
+GASNET_PSHM_NODES=2 ./build/run-fpm.sh test --flag "-fcoarray=single -DUSE_CAFFEINE"
 ```
 Change '2' above to the number of images that you would like to launch in parallel.
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Running and Testing
 With `gfortran` installed, build, run and test Matcha in a single image by entering the following commands in a `bash`-like shell:
 ```
 ./install.sh
-./build/run-fpm.sh run
-./build/run-fpm.sh test
+./build/run-fpm.sh run --flag "-fcoarray=single"
+./build/run-fpm.sh test --flag "-fcoarray=single"
 ```
 ### Multi-image (parallel) execution
 With `gfortran` and OpenCoarrays installed, build, run and test Matcha in multiple images by entering the following commands in a `bash`-like shell:

--- a/README.md
+++ b/README.md
@@ -25,23 +25,23 @@ Building
 --------
 With `gfortran` build Matcha in a single image by entering the following commands in a `bash`-like shell:
 ```
-./install.sh
+./setup.sh
 ```
-or execute `.install.sh -h` to see a list of options the installer accepts.
+or execute `.setup.sh -h` to see a list of options the installer accepts.
 
 Running and Testing
 -------------------
 ### Single-image (serial) execution
 With `gfortran` installed, build, run and test Matcha in a single image by entering the following commands in a `bash`-like shell:
 ```
-./install.sh
+./setup.sh
 ./build/run-fpm.sh run --flag "-fcoarray=single"
 ./build/run-fpm.sh test --flag "-fcoarray=single"
 ```
 ### Multi-image (parallel) execution
 With `gfortran` and OpenCoarrays installed, build, run and test Matcha in multiple images by entering the following commands in a `bash`-like shell:
 ```
-./install.sh
+./setup.sh
 ./build/run-fpm.sh run --compiler caf --runner "cafrun -n 2"
 ./build/run-fpm.sh test --compiler caf --runner "cafrun -n 2"
 ```
@@ -49,7 +49,7 @@ Change '2' above to the number of images that you would like to launch in parall
 
 ### Parallel Execution with Caffeine
 ```
-./install.sh
+./setup.sh
 GASNET_PSHM_NODES=2 ./build/run-fpm.sh run --flag "-DUSE_CAFFEINE"
 GASNET_PSHM_NODES=2 ./build/run-fpm.sh test --flag "-DUSE_CAFFEINE"
 ```

--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ echo "#-- DO NOT EDIT -- created by matcha/install.sh"                        >>
 echo "\"${FPM}\" \"\$@\" \\"                                                  >> $RUN_FPM_SH
 echo "--c-compiler \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CC`\" \\"  >> $RUN_FPM_SH
 echo "--c-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_CFLAGS`\" \\"  >> $RUN_FPM_SH
-echo "--flag \"-Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds -fcheck=array-temps -fbacktrace -fcoarray=single\" \\" >> $RUN_FPM_SH
+echo "--flag \"-O3 -Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds -fcheck=array-temps -fbacktrace\" \\" >> $RUN_FPM_SH
 echo "--link-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`\"" >> $RUN_FPM_SH
 chmod u+x $RUN_FPM_SH
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,16 +4,16 @@ set -e # exit on error
 
 print_usage_info()
 {
-    echo "Matcha Installation Script"
+    echo "Matcha Setup Script"
     echo ""
     echo "USAGE:"
-    echo "./install.sh [--help | [--prefix=PREFIX]"
+    echo "./setup.sh [--help | [--prefix=PREFIX]"
     echo ""
     echo " --help             Display this help text"
-    echo " --prefix=PREFIX    Install binary in 'PREFIX/bin' (default: '\$HOME/.local/bin')"
+    echo " --prefix=PREFIX    Install prerequisites in 'PREFIX/bin' (default: '\$HOME/.local/bin')"
     echo ""
     echo "For a non-interactive build with the 'yes' utility installed, execute"
-    echo "yes | ./install.sh"
+    echo "yes | ./setup.sh"
 }
 
 while [ "$1" != "" ]; do
@@ -83,7 +83,6 @@ echo "--link-flag \"`$PKG_CONFIG caffeine --variable=CAFFEINE_FPM_LDFLAGS`\"" >>
 chmod u+x $RUN_FPM_SH
 
 cp templates/fpm.toml .
-./$RUN_FPM_SH build
 
 echo ""
 echo "________________ Matcha has been poured! ________________"


### PR DESCRIPTION
Remove the `-fcoarray=single` flag from the `run-fpm.sh` script and specify it in the README.