### PR TITLE
Minor fixes

### DIFF
--- a/src/matcha_m.f90
+++ b/src/matcha_m.f90
@@ -9,7 +9,7 @@ module matcha_m
   
   implicit none
 
-  interface matcha
+  interface
 
     module function matcha(input) result(history)
       implicit none

--- a/src/matcha_s.F90
+++ b/src/matcha_s.F90
@@ -3,7 +3,6 @@
 submodule(matcha_m) matcha_s
   use t_cell_collection_m, only : t_cell_collection_t
   use distribution_m, only : distribution_t
-  use input_m, only : input_t
   use data_partition_m, only : data_partition_t
   
 #ifdef USE_CAFFEINE


### PR DESCRIPTION
This commit 

1. Removes a generic interface name that matched the corresponding procedure name and
2. Removes an unnecessary `use` statement.

Both issues were identified when compiling on [Cori](https://www.nersc.gov/systems/cori/).