### PR TITLE
Improve memory management

### DIFF
--- a/src/matcha/input_m.f90
+++ b/src/matcha/input_m.f90
@@ -8,7 +8,7 @@ module input_m
   
   type input_t
     private
-    integer :: num_cells_ = 1000, num_positions_ = 1000, num_dimensions_ = 3, num_intervals_ = 4
+    integer :: num_cells_ = 6000, num_positions_ = 6000, num_dimensions_ = 3, num_intervals_ = 4
     double precision :: time_step_ = 0.1D0
     !double precision, allocatable :: sample_distribution_(:,:)
     !allocate(sample_distribution_(num_intervals_,2))

--- a/src/matcha/t_cell_collection_m.f90
+++ b/src/matcha/t_cell_collection_m.f90
@@ -21,7 +21,7 @@ module t_cell_collection_m
   interface t_cell_collection_t
     
     pure module function construct(positions, time) result(t_cell_collection)
-      !! Return a t_cell_collection_t object rescaled position vectors and the provided time stamp
+      !! Return a t_cell_collection_t object with rescaled position vectors and the provided time stamp
       implicit none
       double precision, intent(in) :: positions(:,:), time
       type(t_cell_collection_t) t_cell_collection

--- a/src/matcha_s.F90
+++ b/src/matcha_s.F90
@@ -49,11 +49,11 @@ contains
           
               associate(random_speeds => random_4vectors(:,:,1), random_directions => random_4vectors(:,:,2:4))
                 associate(v => distribution%velocities(random_speeds, random_directions))
-                  allocate(history(nsteps+1))
+                  allocate(history(nsteps))
                   history(1) = t_cell_collection_t(scale*random_positions, time=0.D0)
-                  do step = 1, nsteps
-                    associate(x => history(step)%positions(), t => history(step)%time())
-                      history(step+1) = t_cell_collection_t(x + v(:,step,:)*dt, t + dt)
+                  do step = 2, nsteps
+                    associate(x => history(step-1)%positions(), t => history(step-1)%time())
+                      history(step) = t_cell_collection_t(x + v(:,step-1,:)*dt, t + dt)
                     end associate
                   end do
                 end associate

--- a/src/matcha_s.F90
+++ b/src/matcha_s.F90
@@ -49,10 +49,11 @@ contains
           
               associate(random_speeds => random_4vectors(:,:,1), random_directions => random_4vectors(:,:,2:4))
                 associate(v => distribution%velocities(random_speeds, random_directions))
-                  history = [t_cell_collection_t(scale*random_positions, time=0.D0)]
+                  allocate(history(nsteps+1))
+                  history(1) = t_cell_collection_t(scale*random_positions, time=0.D0)
                   do step = 1, nsteps
                     associate(x => history(step)%positions(), t => history(step)%time())
-                      history = [history, t_cell_collection_t(x + v(:,step,:)*dt, t + dt)]
+                      history(step+1) = t_cell_collection_t(x + v(:,step,:)*dt, t + dt)
                     end associate
                   end do
                 end associate


### PR DESCRIPTION
Given a history vector storing N time steps, this pull request reduces the cumulative memory allocation from O(N^2) to O(N) by allocating the entire history vector once rather than growing it by one element at each time step.  This greatly reduces execution times.