### PR TITLE
Finish C-interoperability and simplify nested associations

### DIFF
--- a/src/matcha/distribution_s.F90
+++ b/src/matcha/distribution_s.F90
@@ -54,7 +54,7 @@ contains
     call assert(allocated(self%vel_), "distribution_t%cumulative_distribution: allocated(vel_)")
 
      ! Sample from the distribution
-     sampled_speeds = do_concurrent_sampled_speeds(speeds, self%vel_, self%cumulative_distribution())
+     call do_concurrent_sampled_speeds(speeds, self%vel_, self%cumulative_distribution(), sampled_speeds)
      
      associate(nsteps => size(speeds,2))
 

--- a/src/matcha/do_concurrent_m.f90
+++ b/src/matcha/do_concurrent_m.f90
@@ -3,8 +3,8 @@ module do_concurrent_m
   use t_cell_collection_m, only : t_cell_collection_t, t_cell_collection_bind_C_t
   implicit none
   private
-  public :: do_concurrent_sampled_speeds, do_concurrent_my_velocities, do_concurrent_k,& 
-  do_concurrent_output_distribution, do_concurrent_x, do_concurrent_speeds
+  public :: do_concurrent_sampled_speeds, do_concurrent_my_velocities, do_concurrent_k, do_concurrent_speeds
+  public :: do_concurrent_output_distribution
   
   interface
     
@@ -35,15 +35,8 @@ module do_concurrent_m
       real(c_double), intent(out), allocatable :: output_distribution(:,:)
     end subroutine
     
-    module subroutine do_concurrent_x(history, x) bind(C)
+    module subroutine do_concurrent_speeds(history, speeds) bind(C)
       implicit none
-      type(t_cell_collection_bind_C_t), intent(in) :: history(:)
-      real(c_double), intent(out), allocatable :: x(:,:,:)
-    end subroutine  
-    
-    pure module subroutine do_concurrent_speeds(x, history, speeds) bind(C)
-      implicit none
-      real(c_double), intent(in) :: x(:,:,:)
       type(t_cell_collection_bind_C_t), intent(in) :: history(:)
       real(c_double), intent(out), allocatable :: speeds(:)
     end subroutine

--- a/src/matcha/do_concurrent_m.f90
+++ b/src/matcha/do_concurrent_m.f90
@@ -8,11 +8,11 @@ module do_concurrent_m
   
   interface
     
-    pure module function do_concurrent_sampled_speeds(speeds, vel, cumulative_distribution) result(sampled_speeds)
+    pure module subroutine do_concurrent_sampled_speeds(speeds, vel, cumulative_distribution, sampled_speeds) bind(C)
       implicit none
-      double precision, intent(in) :: speeds(:,:), vel(:), cumulative_distribution(:)
-      double precision, allocatable :: sampled_speeds(:,:)
-    end function
+      real(c_double), intent(in) :: speeds(:,:), vel(:), cumulative_distribution(:)
+      real(c_double), intent(out), allocatable :: sampled_speeds(:,:)
+    end subroutine
     
     pure module subroutine do_concurrent_my_velocities(nsteps, dir, sampled_speeds, my_velocities) bind(C)
       implicit none
@@ -27,8 +27,8 @@ module do_concurrent_m
       integer(c_int), intent(out), allocatable :: k(:)
     end subroutine
     
-    pure module subroutine do_concurrent_output_distribution(nintervals, speed, freq, emp_distribution, k,&
-     output_distribution) bind(C)
+    pure module subroutine &
+      do_concurrent_output_distribution(nintervals, speed, freq, emp_distribution, k, output_distribution) bind(C)
       implicit none
       integer(c_int), intent(in) :: nintervals, speed, freq, k(:)
       real(c_double), intent(in) :: emp_distribution(:,:)
@@ -41,12 +41,12 @@ module do_concurrent_m
       real(c_double), intent(out), allocatable :: x(:,:,:)
     end subroutine  
     
-    pure module function do_concurrent_speeds(x, history) result(speeds)
+    pure module subroutine do_concurrent_speeds(x, history, speeds) bind(C)
       implicit none
       real(c_double), intent(in) :: x(:,:,:)
       type(t_cell_collection_bind_C_t), intent(in) :: history(:)
-      real(c_double), allocatable :: speeds(:)
-    end function
+      real(c_double), intent(out), allocatable :: speeds(:)
+    end subroutine
       
   end interface
   

--- a/src/matcha/do_concurrent_s.f90
+++ b/src/matcha/do_concurrent_s.f90
@@ -23,14 +23,14 @@ contains
   
     integer step
     
-      if(allocated(my_velocities)) deallocate(my_velocities)
-      allocate(my_velocities, mold=dir)
-      
-      do concurrent(step=1:nsteps)
-        my_velocities(:,step,1) = sampled_speeds(:,step)*dir(:,step,1)
-        my_velocities(:,step,2) = sampled_speeds(:,step)*dir(:,step,2)
-        my_velocities(:,step,3) = sampled_speeds(:,step)*dir(:,step,3)
-      end do
+    if(allocated(my_velocities)) deallocate(my_velocities)
+    allocate(my_velocities, mold=dir)
+    
+    do concurrent(step=1:nsteps)
+      my_velocities(:,step,1) = sampled_speeds(:,step)*dir(:,step,1)
+      my_velocities(:,step,2) = sampled_speeds(:,step)*dir(:,step,2)
+      my_velocities(:,step,3) = sampled_speeds(:,step)*dir(:,step,3)
+    end do
     
   end procedure
   
@@ -73,7 +73,6 @@ contains
 
       allocate(x(npositions,ncells,nspacedims))
 
-      !do concurrent(i=1:npositions)
       do i=1,npositions
          call c_f_pointer(history(i)%positions_ptr, positions, history(1)%positions_shape)
          x(i,:,:) = positions

--- a/src/matcha/do_concurrent_s.f90
+++ b/src/matcha/do_concurrent_s.f90
@@ -86,9 +86,7 @@ contains
     integer i, j, k
     integer, parameter :: nspacedims=3
     
-    associate(npositions => size(history))
-    associate(ncells => history(1)%positions_shape(1))
-    associate(t => history%time)
+    associate(npositions => size(history), ncells => history(1)%positions_shape(1), t => history%time)
       allocate(speeds(ncells*(npositions-1)))
       do concurrent(i = 1:npositions-1, j = 1:ncells)
         associate( &
@@ -98,8 +96,6 @@ contains
           speeds(ij) = sqrt(sum([(u(k)**2, k=1,nspacedims)]))
         end associate
       end do
-    end associate
-    end associate
     end associate
     
   end procedure

--- a/src/matcha/output_s.f90
+++ b/src/matcha/output_s.f90
@@ -25,16 +25,12 @@ contains
     
     integer, parameter :: speed=1, freq=2 ! subscripts for speeds and frequencies
 
-    associate(speeds => sim_speeds(self%history_))
-      associate(emp_distribution => self%input_%sample_distribution())
-        associate(nintervals => size(emp_distribution(:,1)))
-          associate(dvel_half => (emp_distribution(2,speed)-emp_distribution(1,speed))/2.d0)
-            vel = [emp_distribution(1,speed) - dvel_half, [(emp_distribution(i,speed) + dvel_half, i=1,nintervals)]]
-            call do_concurrent_k(speeds, vel, k)
-            call do_concurrent_output_distribution(nintervals, speed, freq, emp_distribution, k, output_distribution)
-            output_distribution(:,freq) = output_distribution(:,freq)/sum(output_distribution(:,freq))
-          end associate
-        end associate
+    associate(speeds => sim_speeds(self%history_), emp_distribution => self%input_%sample_distribution())
+      associate(nintervals => size(emp_distribution(:,1)), dvel_half => (emp_distribution(2,speed)-emp_distribution(1,speed))/2.d0)
+        vel = [emp_distribution(1,speed) - dvel_half, [(emp_distribution(i,speed) + dvel_half, i=1,nintervals)]]
+        call do_concurrent_k(speeds, vel, k)
+        call do_concurrent_output_distribution(nintervals, speed, freq, emp_distribution, k, output_distribution)
+        output_distribution(:,freq) = output_distribution(:,freq)/sum(output_distribution(:,freq))
       end associate
     end associate
 
@@ -47,10 +43,11 @@ contains
       
       associate(bind_C_history => t_cell_collection_bind_C_t(history))
         call do_concurrent_x(bind_C_history, x)
-        speeds = do_concurrent_speeds(x, bind_C_history)
+        call do_concurrent_speeds(x, bind_C_history, speeds)
       end associate
  
     end function
+
   end procedure
 
 end submodule output_s

--- a/src/matcha/output_s.f90
+++ b/src/matcha/output_s.f90
@@ -1,10 +1,9 @@
 ! Copyright (c), The Regents of the University of California
 ! Terms of use are as specified in LICENSE.txt
 submodule(output_m) output_s
-  use do_concurrent_m, only : do_concurrent_k, do_concurrent_output_distribution, &
-    do_concurrent_x, do_concurrent_speeds
+  use do_concurrent_m, only : do_concurrent_k, do_concurrent_output_distribution, do_concurrent_speeds
   use t_cell_collection_m, only : t_cell_collection_bind_C_t
-  use iso_c_binding, only : c_loc 
+  use iso_c_binding, only : c_loc, c_double
   implicit none
   
 contains
@@ -21,11 +20,13 @@ contains
   module procedure simulated_distribution
     integer i
     integer, allocatable :: k(:)
-    double precision, allocatable :: vel(:)
+    real(c_double), allocatable, dimension(:) :: vel, speeds
     
     integer, parameter :: speed=1, freq=2 ! subscripts for speeds and frequencies
 
-    associate(speeds => sim_speeds(self%history_), emp_distribution => self%input_%sample_distribution())
+    call do_concurrent_speeds(t_cell_collection_bind_C_t(self%history_), speeds)
+
+    associate(emp_distribution => self%input_%sample_distribution())
       associate(nintervals => size(emp_distribution(:,1)), dvel_half => (emp_distribution(2,speed)-emp_distribution(1,speed))/2.d0)
         vel = [emp_distribution(1,speed) - dvel_half, [(emp_distribution(i,speed) + dvel_half, i=1,nintervals)]]
         call do_concurrent_k(speeds, vel, k)
@@ -33,20 +34,6 @@ contains
         output_distribution(:,freq) = output_distribution(:,freq)/sum(output_distribution(:,freq))
       end associate
     end associate
-
-  contains
-
-    function sim_speeds(history) result(speeds)
-      type(t_cell_collection_t), intent(in) :: history(:)
-      double precision, allocatable :: speeds(:)
-      double precision, allocatable :: x(:,:,:)
-      
-      associate(bind_C_history => t_cell_collection_bind_C_t(history))
-        call do_concurrent_x(bind_C_history, x)
-        call do_concurrent_speeds(x, bind_C_history, speeds)
-      end associate
- 
-    end function
 
   end procedure
 


### PR DESCRIPTION
This commit

1. Combines nested associate statements where possible,
2. Combines two `do_concurrent_*` procedures into one,
3. Adds `bind(C)` the two remaining procedures in `do_concurrent_m`,
4. Makes the changes that `bind(C)` necessitates, including 
  a. Switching to interoperable types and 
  b. Switching functions to subroutines

The previous functions had allocatable array results, whereas the Fortran 2018 standard clause 18.3.6 requires scalar function results for `bind(C)` functions.

This PR speeds up single-image runs about 33% and preserves the parallel scalability:

Images | execution time | speedup
:-           | :-:                       | :-
1            | 22 sec               |
2           | 10.3                    | 2.1
4           | 5.5                      | 4
8           | 3.4                      | 6.5 