### PR TITLE
Feature: add & test procedural alternative

### DIFF
--- a/src/matcha/subdomain_m.f90
+++ b/src/matcha/subdomain_m.f90
@@ -9,6 +9,7 @@ module subdomain_m
     real, allocatable :: s_(:,:)
   contains
     procedure, pass(self) :: define
+    procedure, pass(self) :: step
     procedure :: laplacian
     generic :: operator(.laplacian.) => laplacian
     procedure, pass(rhs) :: multiply
@@ -29,6 +30,12 @@ module subdomain_m
       real, intent(in) :: side, boundary_val, internal_val
       integer, intent(in) :: n !! number of grid points in each coordinate direction
       class(subdomain_t), intent(out) :: self
+    end subroutine
+
+    module subroutine step(alpha_dt, self)
+      implicit none
+      real, intent(in) :: alpha_dt
+      class(subdomain_t), intent(inout) :: self
     end subroutine
 
     pure module function values(self) result(my_values)

--- a/src/matcha/subdomain_s.f90
+++ b/src/matcha/subdomain_s.f90
@@ -119,4 +119,81 @@ contains
     my_values =  self%s_
   end procedure
 
+  module procedure step
+
+    real, allocatable :: increment(:,:)
+
+    call assert(allocated(self%s_), "subdomain_t%laplacian: allocated(rhs%s_)")
+    call assert(allocated(halo_x), "subdomain_t%laplacian: allocated(halo_x)")
+    call assert(my_internal_left+1<=my_nx,"laplacian: leftmost subdomain too small")
+    call assert(my_internal_right-1>0,"laplacian: rightmost subdomain too small")
+
+    allocate(increment(my_nx,ny))
+ 
+    call internal_points(increment)
+    call edge_points(increment)
+    call apply_boundary_condition(increment)
+
+    sync all
+    self%s_ = self%s_ + increment
+    sync all
+    call exchange_halo(self%s_)
+
+  contains
+
+    subroutine internal_points(ds)
+      real, intent(inout) :: ds(:,:)
+      integer i, j
+
+      do concurrent(i=my_internal_left+1:my_internal_right-1, j=2:ny-1)
+        ds(i,j) = alpha_dt*( &
+          (self%s_(i-1,j) - 2*self%s_(i,j) + self%s_(i+1,j))/dx_**2 + &
+          (self%s_(i,j-1) - 2*self%s_(i,j) + self%s_(i,j+1))/dy_**2 &
+        )
+      end do
+    end subroutine
+
+    subroutine edge_points(ds)
+      real, intent(inout) :: ds(:,:)
+      real, allocatable :: halo_left(:), halo_right(:)
+      integer i, j
+
+      halo_left = merge(halo_x(west,:), self%s_(1,:), me/=1)
+      halo_right = merge(halo_x(east,:), self%s_(my_nx,:), me/=num_subdomains)
+
+      i = my_internal_left
+      do concurrent(j=2:ny-1)
+        ds(i,j) = alpha_dt*( &
+          (halo_left(j)   - 2*self%s_(i,j) + self%s_(i+1,j))/dx_**2 + &
+          (self%s_(i,j-1)  - 2*self%s_(i,j) + self%s_(i,j+1))/dy_**2 &
+        )
+      end do
+
+      i = my_internal_right
+      do concurrent(j=2:ny-1)
+        ds(i,j) = alpha_dt*( &
+          (self%s_(i-1,j)  - 2*self%s_(i,j) + halo_right(j))/dx_**2 + &
+          (self%s_(i,j-1) - 2*self%s_(i,j) + self%s_(i,j+1))/dy_**2 &
+        )
+      end do
+    end subroutine
+
+    subroutine apply_boundary_condition(ds)
+      real, intent(inout) :: ds(:,:)
+      integer i, j
+
+      ds(:, 1) = 0.
+      ds(:,ny) = 0.
+      if (me==1) ds(1,:) = 0.
+      if (me==num_subdomains) ds(my_nx,:) = 0.
+    end subroutine
+
+    subroutine exchange_halo(s)
+      real, intent(in) :: s(:,:)
+      if (me>1) halo_x(east,:)[me-1] = s(1,:)
+      if (me<num_subdomains) halo_x(west,:)[me+1] = s(my_nx,:)
+    end subroutine
+
+  end procedure
+
 end submodule subdomain_s

--- a/test/subdomain_test_m.f90
+++ b/test/subdomain_test_m.f90
@@ -29,10 +29,12 @@ contains
     test_results = test_result_t( &
       [ character(len=len("computing a correctly shaped Laplacian for a 2D flat-topped, step-like plateau")) :: &
         "computing a correctly shaped Laplacian for a 2D flat-topped, step-like plateau", &
-        "reaching the correct steady state solution" &
+        "reaching the correct steady state solution", &
+        "functional pattern results matching procedural results" &
       ], &
       [ correctly_shaped_laplacian(),  &
-        correct_steady_state()  &
+        correct_steady_state(),  &
+        functional_matches_procedural()  &
        ] &
     )
   end function
@@ -136,4 +138,35 @@ contains
 
   end function
 
+  function functional_matches_procedural() result(test_passes)
+     logical test_passes
+     type(subdomain_t) T, T_ref
+     real, parameter :: T_boundary = 1., T_initial = 2.
+
+     call T_ref%define(side=1., boundary_val=T_boundary, internal_val=T_initial, n=51)
+       ! spatially constant internal temperatuers with a step change at the boundaries
+     T = T_ref
+
+     block
+       integer step
+       integer, parameter :: steps = 5000
+       real, parameter :: alpha = 1.
+
+       associate(dt => T%dx()*T%dy()/(4*alpha))
+         do step = 1, steps
+           T =  T + dt * alpha * .laplacian. T
+           call T_ref%step(alpha*dt)
+         end do
+       end associate
+     end block
+
+     block
+       real, parameter :: tolerance = 0.001
+
+       associate( L_infinity_norm => maxval(abs(T%values() - T_ref%values())))
+         test_passes = L_infinity_norm < tolerance
+       end associate
+     end block
+
+  end function
 end module subdomain_test_m


### PR DESCRIPTION
This PR adds 
- [x] A `step` subroutine that increments the subdomain state vector one time step using a more traditional, procedural style of programming.
- [x] A unit test that verifies that the procedural and functional approaches produce the same result with an L-infinity norm tolerance of 0.001