### PR TITLE
Simplify heat-conduction example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 doc/html
+a.out
 *.o
 *.mod
 *.smod


### PR DESCRIPTION
1. Remove user-defined `operator(*)` & `assignment(=)`.
2. Simplify the grid partitioning calculation.
3. Reduce synchronization and & move synchronization to `main`