### PR TITLE
[NOT WORKING] CI: Add gfortran 15 on Linux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,12 @@ jobs:
             extra_flags: -g -ffree-line-length-0
             oc_version: 2.10.3
 
+          - os: ubuntu-24.04
+            compiler: gfortran
+            version: 15
+            extra_flags: -g 
+            oc_version: 2.10.3
+
     env:
       COMPILER_VERSION: ${{ matrix.version }}
       OC_VERSION: ${{ matrix.oc_version }}
@@ -66,7 +72,28 @@ jobs:
         set -x
         sudo apt update
         sudo apt install -y build-essential pkg-config make
-        sudo apt install -y gfortran-${COMPILER_VERSION} g++-${COMPILER_VERSION}
+        if [[ ${COMPILER_VERSION} < 15 ]] ; then \
+          sudo apt install -y gfortran-${COMPILER_VERSION} g++-${COMPILER_VERSION} ; \
+        else \
+          curl -L https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o install-homebrew.sh ; \
+          chmod +x install-homebrew.sh ; \
+          env CI=1 ./install-homebrew.sh ; \
+          HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" ; \
+          ${HOMEBREW_PREFIX}/bin/brew install -v gcc@${COMPILER_VERSION} binutils ; \
+          ls -al ${HOMEBREW_PREFIX}/bin ; \
+          echo "PATH=${HOMEBREW_PREFIX}/bin:${PATH}" >> "$GITHUB_ENV" ; \
+          echo "LD_LIBRARY_PATH=${HOMEBREW_PREFIX}/lib64:${HOMEBREW_PREFIX}/lib:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV" ; \
+          : Homebrew GCC@15 needs binutils 2.44+ ; \
+          HOMEBREW_BINUTILS=$(ls -d ${HOMEBREW_PREFIX}/Cellar/binutils/2.*/bin ) ; \
+          ls -al ${HOMEBREW_BINUTILS} ; \
+          echo "FFLAGS=${FFLAGS:+"$FFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          echo "CFLAGS=${CFLAGS:+"$CFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          echo "CXXFLAGS=${CXXFLAGS:+"$CXXFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          echo "LDFLAGS=${LDFLAGS:+"$LDFLAGS" }-B ${HOMEBREW_BINUTILS}" >> "$GITHUB_ENV" ; \
+          for tool in $(cd ${HOMEBREW_BINUTILS} ; ls ) ; do \
+             sudo ln -sf ${HOMEBREW_BINUTILS}/$tool /usr/bin/$tool ; \
+          done
+        fi  
 
     - name: OpenCoarrays/MPICH Cache
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.container == '' }}


### PR DESCRIPTION
@rouson Here is my failed attempt to build Matcha on Linux ubuntu-latest with gfortran 15.2.0, OpenCoarrays 2.10.3 and the OC's default MPICH 3.2.

The link errors I mentioned today look like this:
```

/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: build/caf_33623D7BE955BBCD/matcha/libmatcha.a(src_matcha_subdomain_s.F90.o): warning: relocation against `__caf_send_to_remote_fn_index_5.10' in read-only section `.text'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: build/caf_33623D7BE955BBCD/matcha/libmatcha.a(src_matcha_subdomain_s.F90.o): in function `__subdomain_m_MOD_assign_and_sync':
/home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:161:(.text+0x82cd): undefined reference to `__caf_send_to_remote_fn_index_2.13'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: /home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:161:(.text+0x82eb): undefined reference to `__caf_send_to_remote_fn_index_2.13'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: /home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:162:(.text+0x863e): undefined reference to `__caf_send_to_remote_fn_index_3.12'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: /home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:162:(.text+0x865c): undefined reference to `__caf_send_to_remote_fn_index_3.12'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: build/caf_33623D7BE955BBCD/matcha/libmatcha.a(src_matcha_subdomain_s.F90.o): in function `__subdomain_m_MOD_define':
/home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:66:(.text+0xf045): undefined reference to `__caf_send_to_remote_fn_index_4.11'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: /home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:66:(.text+0xf062): undefined reference to `__caf_send_to_remote_fn_index_4.11'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: /home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:67:(.text+0xf3a7): undefined reference to `__caf_send_to_remote_fn_index_5.10'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: /home/runner/work/matcha/matcha/././src/matcha/subdomain_s.F90:67:(.text+0xf3c4): undefined reference to `__caf_send_to_remote_fn_index_5.10'
/home/linuxbrew/.linuxbrew/Cellar/binutils/2.45.1/bin/ld: warning: creating DT_TEXTREL in a PIE
```

I get very similar link failures if I install MPICH 4.3.2 and use that instead (using [this commit](https://github.com/bonachea/matcha/commit/14bc2002c038773e80fc01e5b4096fcc177a28f7))

I don't know how to fix this problem and this is the reason I was unable to add GCC 15.x testing to Matcha.